### PR TITLE
III-3771 Upgrade cultuurnet/valueobjects to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "cultuurnet/valueobjects": "~3.0",
+    "cultuurnet/valueobjects": "^4.0",
     "psr/http-message": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
### Changed
 
- Upgrade cultuurnet/valueobjects to v4 which uses ramsey/uuid v3 
 
---
Ticket: https://jira.uitdatabank.be/browse/III-3771
